### PR TITLE
core,internal/ethapi: implement EVM++ call logs

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -87,6 +87,7 @@ type StateDB interface {
 
 	AddLog(*types.Log)
 	AddPreimage(common.Hash, []byte)
+	Logs() []*types.Log
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
 }


### PR DESCRIPTION
pass an `accessList: [{ address: '0x5555555555555555555555555555555555555555' }]` in `eth_call` to extract the all logs generated by the contract call